### PR TITLE
Fix https://github.com/realestate-com-au/tagfish/issues/2

### DIFF
--- a/lib/tagfish/docker_registry_v2_client.rb
+++ b/lib/tagfish/docker_registry_v2_client.rb
@@ -35,7 +35,7 @@ module Tagfish
       end
       
       tags_with_hashes = tag_names.inject({}) do |dict, tag|
-        dict[tag] = hash(tag)["fsLayers"][0]["blobSum"]
+        dict[tag] = hash(tag)["fsLayers"]
         dict
       end
     end


### PR DESCRIPTION
The structure of the manifest has changed, see
https://github.com/docker/distribution/blob/master/docs/spec/api.md#pulling-an-image-manifest
All the layers hashes are returned for every manifest, so instead of
comparing the only hash, we compare the all table of hashes.
