### PR TITLE
Allow this gem to run alongside json 1.8 or 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Clement Labbe <clement.labbe@rea-group.com>
 
 RUN apk add --update \
     make \
+    g++ \
     diffutils \
     ca-certificates && \
     rm /var/cache/apk/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1-alpine@sha256:8d5ca285f1a24ed333aad70cfa54157f77ff130f810c91d566
+FROM ruby:2.3.1-alpine@sha256:8d5ca285f1a24ed333aad70cfa54157f77ff130f810c91d5664e98a093d751bc
 
 MAINTAINER Clement Labbe <clement.labbe@rea-group.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ruby:2.3-alpine@sha256:f67176f154d709747aee8ba2447bcd35403b7368d3e628466c45fa59ce69dbb1
+FROM ruby:2.3.1-alpine@sha256:8d5ca285f1a24ed333aad70cfa54157f77ff130f810c91d566
 
 MAINTAINER Clement Labbe <clement.labbe@rea-group.com>
 
 RUN apk add --update \
+    make \
     diffutils \
     ca-certificates && \
     rm /var/cache/apk/* && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,6 +3,7 @@ FROM ruby:2.3.1-alpine@sha256:8d5ca285f1a24ed333aad70cfa54157f77ff130f810c91d566
 MAINTAINER Clement Labbe <clement.labbe@rea-group.com>
 
 RUN apk add --update \
+    make \
     diffutils \
     git \
     ca-certificates && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine@sha256:f67176f154d709747aee8ba2447bcd35403b7368d3e628466c45fa59ce69dbb1
+FROM ruby:2.3.1-alpine@sha256:8d5ca285f1a24ed333aad70cfa54157f77ff130f810c91d5664e98a093d751bc
 
 MAINTAINER Clement Labbe <clement.labbe@rea-group.com>
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,7 @@ MAINTAINER Clement Labbe <clement.labbe@rea-group.com>
 
 RUN apk add --update \
     make \
+    g++ \
     diffutils \
     git \
     ca-certificates && \

--- a/auto/dev-environment
+++ b/auto/dev-environment
@@ -7,5 +7,7 @@ cd $(dirname $0)/..
 trap "docker-compose down --volumes" 0
 
 docker volume create --name ruby2.3-bundle-cache > /dev/null
+
+docker-compose build dev
 docker-compose run --rm dev sh -c 'bundle check > /dev/null || bundle install'
 docker-compose run --rm dev bundle exec "${@-sh}"

--- a/tagfish.gemspec
+++ b/tagfish.gemspec
@@ -23,5 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3.0"
   spec.add_dependency "clamp", "~> 1.1.0"
   spec.add_dependency "diffy", "~> 3.0.0"
-  spec.add_dependency "json", "~> 1.8.0"
+
+  # For lack of a better way to say 1.8.*, 1.9.*, 2.0.*
+  spec.add_dependency "json", [ "> 1.8.0", "< 2.1.0" ]
 end

--- a/tagfish.gemspec
+++ b/tagfish.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3.0"
-  spec.add_dependency "clamp", "~> 1.0.0"
+  spec.add_dependency "clamp", "~> 1.1.0"
   spec.add_dependency "diffy", "~> 3.0.0"
   spec.add_dependency "json", "~> 1.8.0"
 end


### PR DESCRIPTION
It seems apline docker image requires both `make` and `g++` in order to build the newer `json` gem.